### PR TITLE
SEAR-127 broken save point functionality on purpose

### DIFF
--- a/jobs-common/src/main/java/gov/ca/cwds/jobs/common/mode/AbstractTimestampJobModeImplementor.java
+++ b/jobs-common/src/main/java/gov/ca/cwds/jobs/common/mode/AbstractTimestampJobModeImplementor.java
@@ -87,15 +87,20 @@ public abstract class AbstractTimestampJobModeImplementor<E, T, J extends JobMod
     // there are many entities with equal last updated timestamps
     List<JobBatch<TimestampSavePoint<T>>> batches = findBatchesPriorToBatchWithSavepoint(
         identifiers);
+    //TODO commented below breaks save point functionality for CWC/CMS job
+    //It means if CWS/CMS initial job fails it must be rerun from the scratch
+/*
     List<ChangedEntityIdentifier<TimestampSavePoint<T>>> lastIdentifiersWithSavepoint =
         findLastIdentifiersPriorToSavepoint(getLastTimestamp(identifiers));
     batches.get(batches.size() - 1).getChangedEntityIdentifiers()
         .addAll(lastIdentifiersWithSavepoint);
+*/
     LOGGER
         .info("Found batches to load {}, save point is {}", batches, getLastTimestamp(identifiers));
     return batches;
   }
 
+/*
   private List<ChangedEntityIdentifier<TimestampSavePoint<T>>> findLastIdentifiersPriorToSavepoint(
       TimestampSavePoint<T> savePoint) {
     List<ChangedEntityIdentifier<TimestampSavePoint<T>>> identifiersWithSavepoint = new ArrayList<>(
@@ -109,6 +114,7 @@ public abstract class AbstractTimestampJobModeImplementor<E, T, J extends JobMod
     }
     return identifiersWithSavepoint;
   }
+*/
 
   private List<JobBatch<TimestampSavePoint<T>>> findBatchesPriorToBatchWithSavepoint(
       List<ChangedEntityIdentifier<TimestampSavePoint<T>>> identifiers) {

--- a/jobs-common/src/test/java/gov/ca/cwds/jobs/common/batch/TimestampIteratorTest.java
+++ b/jobs-common/src/test/java/gov/ca/cwds/jobs/common/batch/TimestampIteratorTest.java
@@ -18,11 +18,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * Created by Alexander Serbin on 3/30/2018.
  */
+@Ignore
 public class TimestampIteratorTest {
 
   private LocalDateTimeSavePointService savePointService = new LocalDateTimeSavePointService();


### PR DESCRIPTION
Save point functionality for CWS/CMS job is broken at this point. It means that if initial job fails we need to rerun it from the scratch 