### PR TITLE
Cluster configuration for Facility index

### DIFF
--- a/jobs-facilities-common/src/main/resources/facility.settings.json
+++ b/jobs-facilities-common/src/main/resources/facility.settings.json
@@ -1,6 +1,6 @@
 {
-  "number_of_shards": 6,
-  "number_of_replicas": 1,
+  "number_of_shards": 1,
+  "number_of_replicas": 2,
   "analysis": {
     "analyzer": {
       "keyword_lowercase": {


### PR DESCRIPTION
Introduced recommendations regarding a number of shards and replicas for the small and static index like Facilities. Index size 1,2 Gb. 3 node cluster. Optimization for reading speed and availability. In the current configuration, we can afford to lose 2 out of 3 data nodes and still have a working index. 

Number of shards: 1
Number of replicas: 2 

More information in articles:
https://www.elastic.co/guide/en/elasticsearch/guide/current/replica-shards.html
https://www.objectrocket.com/blog/elasticsearch/clustered-elasticsearch-indexing-shard-replica-best-practices/
https://blog.trifork.com/2014/01/07/elasticsearch-how-many-shards/

