### PR TITLE
new idm user datamodel support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ project.ext {
     cwdsModelVersion = '0.8.1_629-RC'
     calsApiVersion = '1.0.6'
     coreApiVersion = '1.7.4_829-RC'
-    perryVersion = '4.0.0_938-RC'
+    perryVersion = '4.0.0_979-RC'
     testSupportVersion = '0.5.6_272-RC'
     commonsCliVersion = '1.4'
     commonsLangVersion = '3.6'

--- a/jobs-cap-users/src/main/java/gov/ca/cwds/jobs/cap/users/service/CapChangedUsersService.java
+++ b/jobs-cap-users/src/main/java/gov/ca/cwds/jobs/cap/users/service/CapChangedUsersService.java
@@ -2,7 +2,7 @@ package gov.ca.cwds.jobs.cap.users.service;
 
 import com.google.inject.Inject;
 import gov.ca.cwds.idm.dto.UserAndOperation;
-import gov.ca.cwds.idm.persistence.model.OperationType;
+import gov.ca.cwds.idm.persistence.ns.OperationType;
 import gov.ca.cwds.jobs.cap.users.dto.ChangedUserDto;
 import gov.ca.cwds.jobs.common.RecordChangeOperation;
 import gov.ca.cwds.jobs.common.savepoint.LocalDateTimeSavePointContainer;

--- a/jobs-cap-users/src/test/java/gov/ca/cwds/jobs/cap/users/MockedIdmService.java
+++ b/jobs-cap-users/src/test/java/gov/ca/cwds/jobs/cap/users/MockedIdmService.java
@@ -3,7 +3,7 @@ package gov.ca.cwds.jobs.cap.users;
 import gov.ca.cwds.idm.dto.User;
 import gov.ca.cwds.idm.dto.UserAndOperation;
 import gov.ca.cwds.idm.dto.UsersPage;
-import gov.ca.cwds.idm.persistence.model.OperationType;
+import gov.ca.cwds.idm.persistence.ns.OperationType;
 import gov.ca.cwds.jobs.cap.users.service.IdmService;
 
 import java.time.LocalDateTime;


### PR DESCRIPTION
changes introduced in COG-539 leads us to change the datamodel for the indexing job.
Perry version updated in dependencies. 